### PR TITLE
Attempt to fix deadlock

### DIFF
--- a/master/buildbot/locks.py
+++ b/master/buildbot/locks.py
@@ -85,7 +85,7 @@ class BaseLock:
 
         # Find all waiters ahead of the requester in the wait queue
         for idx, waiter in enumerate(self.waiting):
-            if waiter[0] == requester:
+            if waiter[0] is requester:
                 w_index = idx
                 break
         else:
@@ -96,9 +96,9 @@ class BaseLock:
             # Wants counting access
             return num_excl == 0 and num_counting + len(ahead) < self.maxCount \
                 and all([w[1].mode == 'counting' for w in ahead])
-        else:
-            # Wants exclusive access
-            return num_excl == 0 and num_counting == 0 and len(ahead) == 0
+        else
+            #Wants exclusive access
+            return num_excl == 0 and num_counting == 0 and not ahead
 
     def claim(self, owner, access):
         """ Claim the lock (lock must be available) """
@@ -108,7 +108,7 @@ class BaseLock:
 
         assert isinstance(access, LockAccess)
         assert access.mode in ['counting', 'exclusive']
-        self.waiting = [w for w in self.waiting if w[0] != owner]
+        self.waiting = [w for w in self.waiting if w[0] is not owner]
         self.owners.append((owner, access))
         debuglog(" %s is claimed '%s'" % (self, access.mode))
 
@@ -168,7 +168,7 @@ class BaseLock:
         d = defer.Deferred()
 
         # Are we already in the wait queue?
-        w = [i for i, w in enumerate(self.waiting) if w[0] == owner]
+        w = [i for i, w in enumerate(self.waiting) if w[0] is owner]
         if w:
             self.waiting[w[0]] = (owner, access, d)
         else:
@@ -179,7 +179,7 @@ class BaseLock:
         debuglog("%s stopWaitingUntilAvailable(%s)" % (self, owner))
         assert isinstance(access, LockAccess)
         assert (owner, access, d) in self.waiting
-        self.waiting = [w for w in self.waiting if w[0] != owner]
+        self.waiting = [w for w in self.waiting if w[0] is not owner]
 
     def isOwner(self, owner, access):
         return (owner, access) in self.owners


### PR DESCRIPTION
Cherry-pick of:
 https://github.com/buildbot/buildbot/pull/3650/commits

Only locks.py related changes are applied. Other files
are for integration testing and were ignored.
There is no guarantee that this fix the Deadlock
described in INF-294.

This is part of a bigger patch applied at mainstream
branch for 1.6.0

Explanation taken from the original patch:

If a build factory has a buildstep with a lock, this will
trigger a deadlock whenever 3 or more builds of this factory
 are started at the same time.
The main reason is that BaseLock uses the == operator to
compare the owners of a given lock.
But if owners are BuildSteps, it doesn't work because
they inherit from ComparableMixin (#d6c6b550),
so two distinct BuildStep objects sharing the same properties
will be considered as equal, although they are
distinct Python objects:
`b0 == b1` but `b0 is not b1`.
We use the `is` operator to fix this.